### PR TITLE
exp: strings.Builder vs + 結合のクロスオーバーポイント計測

### DIFF
--- a/experiments/string-concat/concat.go
+++ b/experiments/string-concat/concat.go
@@ -1,0 +1,38 @@
+package stringconcat
+
+import "strings"
+
+// ConcatPlus concatenates parts using the + operator in a loop.
+// Each iteration allocates a new string, resulting in O(N²) copy cost.
+func ConcatPlus(parts []string) string {
+	s := ""
+	for _, p := range parts {
+		s += p
+	}
+	return s
+}
+
+// ConcatBuilder concatenates parts using strings.Builder.
+// The internal buffer grows with a doubling strategy: O(log N) allocations, O(N) copies.
+func ConcatBuilder(parts []string) string {
+	var b strings.Builder
+	for _, p := range parts {
+		b.WriteString(p)
+	}
+	return b.String()
+}
+
+// ConcatBuilderGrow concatenates parts using strings.Builder with pre-allocated capacity.
+// A single allocation is performed upfront, eliminating regrowth overhead.
+func ConcatBuilderGrow(parts []string) string {
+	var b strings.Builder
+	total := 0
+	for _, p := range parts {
+		total += len(p)
+	}
+	b.Grow(total)
+	for _, p := range parts {
+		b.WriteString(p)
+	}
+	return b.String()
+}

--- a/experiments/string-concat/concat_test.go
+++ b/experiments/string-concat/concat_test.go
@@ -1,0 +1,51 @@
+package stringconcat
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// makeParts generates n fixed-length (8 byte) string parts.
+func makeParts(n int) []string {
+	parts := make([]string, n)
+	for i := range parts {
+		parts[i] = strings.Repeat("a", 8)
+	}
+	return parts
+}
+
+var sizes = []int{2, 4, 8, 16, 32, 64}
+
+func BenchmarkConcatPlus(b *testing.B) {
+	for _, n := range sizes {
+		parts := makeParts(n)
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			for b.Loop() {
+				_ = ConcatPlus(parts)
+			}
+		})
+	}
+}
+
+func BenchmarkConcatBuilder(b *testing.B) {
+	for _, n := range sizes {
+		parts := makeParts(n)
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			for b.Loop() {
+				_ = ConcatBuilder(parts)
+			}
+		})
+	}
+}
+
+func BenchmarkConcatBuilderGrow(b *testing.B) {
+	for _, n := range sizes {
+		parts := makeParts(n)
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			for b.Loop() {
+				_ = ConcatBuilderGrow(parts)
+			}
+		})
+	}
+}

--- a/experiments/string-concat/go.mod
+++ b/experiments/string-concat/go.mod
@@ -1,0 +1,3 @@
+module go-lab/experiments/string-concat
+
+go 1.25.7


### PR DESCRIPTION
## Summary

Closes #16

ループ内文字列結合における `+` 演算子と `strings.Builder` の性能逆転点（クロスオーバーポイント）を特定する実験。

## Environment

| Key | Value |
|:---|:---|
| Go | `go1.25.7` |
| OS/Arch | `darwin/arm64` |
| CPU | Apple M2 |

## Results

### Benchmark

```text
BenchmarkConcatPlus/N=2-8                29 ns/op       16 B/op       1 allocs/op
BenchmarkConcatPlus/N=4-8                72 ns/op       72 B/op       3 allocs/op
BenchmarkConcatPlus/N=8-8               172 ns/op      296 B/op       7 allocs/op
BenchmarkConcatPlus/N=16-8              426 ns/op     1128 B/op      15 allocs/op
BenchmarkConcatPlus/N=32-8             1010 ns/op     4328 B/op      31 allocs/op
BenchmarkConcatPlus/N=64-8             3009 ns/op    17128 B/op      63 allocs/op

BenchmarkConcatBuilder/N=2-8             38 ns/op       24 B/op       2 allocs/op
BenchmarkConcatBuilder/N=4-8             70 ns/op       56 B/op       3 allocs/op
BenchmarkConcatBuilder/N=8-8            102 ns/op      120 B/op       4 allocs/op
BenchmarkConcatBuilder/N=16-8           142 ns/op      248 B/op       5 allocs/op
BenchmarkConcatBuilder/N=32-8           247 ns/op      504 B/op       6 allocs/op
BenchmarkConcatBuilder/N=64-8           436 ns/op     1016 B/op       7 allocs/op

BenchmarkConcatBuilderGrow/N=2-8         23 ns/op       16 B/op       1 allocs/op
BenchmarkConcatBuilderGrow/N=4-8         30 ns/op       32 B/op       1 allocs/op
BenchmarkConcatBuilderGrow/N=8-8         42 ns/op       64 B/op       1 allocs/op
BenchmarkConcatBuilderGrow/N=16-8        77 ns/op      128 B/op       1 allocs/op
BenchmarkConcatBuilderGrow/N=32-8       155 ns/op      256 B/op       1 allocs/op
BenchmarkConcatBuilderGrow/N=64-8       312 ns/op      512 B/op       1 allocs/op
```

### Summary Table

| N | `+` ns/op | Builder ns/op | Builder+Grow ns/op | `+` allocs | Builder allocs | Grow allocs |
|:--|--:|--:|--:|--:|--:|--:|
| 2 | 29 | 38 | 23 | 1 | 2 | 1 |
| 4 | 72 | 70 | 30 | 3 | 3 | 1 |
| 8 | 172 | 102 | 42 | 7 | 4 | 1 |
| 16 | 426 | 142 | 77 | 15 | 5 | 1 |
| 32 | 1010 | 247 | 155 | 31 | 6 | 1 |
| 64 | 3009 | 436 | 312 | 63 | 7 | 1 |

- **`+` vs Builder**: N=4 で逆転（72 vs 70 ns/op）。N=8 以降は差が拡大（1.7x〜6.9x）
- **Builder+Grow**: 全ての N で最速。allocs/op は常に 1

## Conclusion

- **Result**: `result:verified`
- 仮説「クロスオーバーポイントは N=4〜8 付近」は検証された。`+` vs Builder の逆転は N=4 で発生。Builder+Grow は想定以上に高速で、N=2 でも `+` を下回り、結合回数が既知なら常に最適解となる。