### PR TITLE
exp: Goroutine 同期手法別ラウンドトリップコスト比較

### DIFF
--- a/experiments/goroutine-cost/goroutine.go
+++ b/experiments/goroutine-cost/goroutine.go
@@ -1,0 +1,28 @@
+package goroutinecost
+
+import "sync"
+
+// SpawnUnbuffered creates a goroutine and synchronizes via an unbuffered channel.
+// The sender blocks until the receiver is ready (rendezvous synchronization).
+func SpawnUnbuffered() {
+	ch := make(chan struct{})
+	go func() { ch <- struct{}{} }()
+	<-ch
+}
+
+// SpawnBuffered creates a goroutine and synchronizes via a buffered channel (cap=1).
+// The sender does not block on send, reducing scheduler intervention.
+func SpawnBuffered() {
+	ch := make(chan struct{}, 1)
+	go func() { ch <- struct{}{} }()
+	<-ch
+}
+
+// SpawnWaitGroup creates a goroutine and synchronizes via sync.WaitGroup.
+// No channel allocation; uses atomic counter internally.
+func SpawnWaitGroup() {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { wg.Done() }()
+	wg.Wait()
+}

--- a/experiments/goroutine-cost/goroutine_test.go
+++ b/experiments/goroutine-cost/goroutine_test.go
@@ -1,0 +1,21 @@
+package goroutinecost
+
+import "testing"
+
+func BenchmarkSpawnUnbuffered(b *testing.B) {
+	for b.Loop() {
+		SpawnUnbuffered()
+	}
+}
+
+func BenchmarkSpawnBuffered(b *testing.B) {
+	for b.Loop() {
+		SpawnBuffered()
+	}
+}
+
+func BenchmarkSpawnWaitGroup(b *testing.B) {
+	for b.Loop() {
+		SpawnWaitGroup()
+	}
+}


### PR DESCRIPTION
## Summary

Closes #18

Goroutine を同期手法別（unbuffered channel / buffered channel / WaitGroup）に計測し、コスト比較を行う。

## Environment

| Key | Value |
|:---|:---|
| Go | `go1.26.0` |
| OS/Arch | `darwin/arm64` |
| CPU | Apple M2 |

## Results

### Benchmark

```text
BenchmarkSpawnUnbuffered-8    3309026    363 ns/op    128 B/op    2 allocs/op
BenchmarkSpawnUnbuffered-8    3343561    364 ns/op    128 B/op    2 allocs/op
BenchmarkSpawnUnbuffered-8    3309381    369 ns/op    128 B/op    2 allocs/op
BenchmarkSpawnUnbuffered-8    3288262    361 ns/op    128 B/op    2 allocs/op
BenchmarkSpawnUnbuffered-8    3029982    365 ns/op    128 B/op    2 allocs/op

BenchmarkSpawnBuffered-8      3510622    343 ns/op    128 B/op    2 allocs/op
BenchmarkSpawnBuffered-8      3452830    342 ns/op    128 B/op    2 allocs/op
BenchmarkSpawnBuffered-8      3462258    320 ns/op    128 B/op    2 allocs/op
BenchmarkSpawnBuffered-8      3877485    311 ns/op    128 B/op    2 allocs/op
BenchmarkSpawnBuffered-8      3487633    342 ns/op    128 B/op    2 allocs/op

BenchmarkSpawnWaitGroup-8     3084571    382 ns/op     32 B/op    2 allocs/op
BenchmarkSpawnWaitGroup-8     3107578    379 ns/op     32 B/op    2 allocs/op
BenchmarkSpawnWaitGroup-8     3275452    370 ns/op     32 B/op    2 allocs/op
BenchmarkSpawnWaitGroup-8     3479830    366 ns/op     32 B/op    2 allocs/op
BenchmarkSpawnWaitGroup-8     3162405    380 ns/op     32 B/op    2 allocs/op
```

### Summary Table

| Metric | Unbuffered ch | Buffered ch | WaitGroup |
|:---|---:|---:|---:|
| ns/op | 363 | 342 | 379 |
| B/op | 128 | 128 | 32 |
| allocs/op | 2 | 2 | 2 |

## Conclusion

- **Result**: `result:unexpected`
- 仮説では WaitGroup が最速と予測したが、実測では Buffered channel が最速（342 ns/op）、WaitGroup が最遅（379 ns/op）だった。ただし B/op は WaitGroup が 32 B と最小で、channel（128 B）の 1/4。レイテンシ優先なら Buffered channel、メモリ効率優先なら WaitGroup という使い分けが示唆される。