### PR TITLE
exp: クロージャの参照キャプチャとヒープ割当の関係調査 #23

### DIFF
--- a/experiments/closure-capture/closure.go
+++ b/experiments/closure-capture/closure.go
@@ -1,0 +1,186 @@
+package closurecapture
+
+// ---- Section 0: Baseline ----
+
+// NoCapture returns a value with no closure at all.
+// Absolute zero point: 0 allocs guaranteed.
+func NoCapture() int {
+	x := 42
+	return x
+}
+
+// ---- Section 1: 2×2 Factorial ----
+
+// PatternA_NonEscapingReadOnly creates a closure that reads a local variable
+// but is called immediately and never stored. Control group: 0 allocs.
+func PatternA_NonEscapingReadOnly() int {
+	x := 42
+	f := func() int { return x }
+	return f()
+}
+
+// PatternB_NonEscapingMutating creates a closure that mutates a local variable
+// via reference capture but is called locally and never returned.
+// Main experiment: does reference capture alone force a heap allocation?
+func PatternB_NonEscapingMutating() int {
+	x := 0
+	f := func() { x++ }
+	f()
+	return x
+}
+
+// PatternC_EscapingReadOnly returns a closure that reads a local variable.
+// Control group: the closure escapes, so ≥1 alloc is expected.
+func PatternC_EscapingReadOnly() func() int {
+	x := 42
+	return func() int { return x }
+}
+
+// PatternD_EscapingMutating returns a closure that mutates a local variable.
+// Control group: escape + mutation, ≥1 alloc expected.
+func PatternD_EscapingMutating() func() int {
+	x := 0
+	f := func() int { x++; return x }
+	return f
+}
+
+// ---- Section 2: Escape Mechanism Variants ----
+
+// globalSink and ifaceSink prevent the compiler from eliding assignments.
+var globalSink func() int
+var ifaceSink interface{}
+
+// EscapeViaGlobal causes a closure to escape by assigning it to a global variable.
+func EscapeViaGlobal() {
+	x := 42
+	globalSink = func() int { return x }
+}
+
+// EscapeViaGoroutine causes a variable to escape via goroutine capture.
+// A buffered channel is used for synchronization without extra allocation.
+func EscapeViaGoroutine() int {
+	x := 42
+	ch := make(chan int, 1)
+	go func() { ch <- x }()
+	return <-ch
+}
+
+// EscapeViaInterface causes a closure to escape by boxing it into an interface{}.
+func EscapeViaInterface() {
+	x := 42
+	f := func() int { return x }
+	ifaceSink = f
+}
+
+// ---- Section 3: IIFE (Immediately Invoked Function Expression) ----
+
+// IIFEReadOnly is an immediately invoked closure that reads a local variable.
+func IIFEReadOnly() int {
+	x := 42
+	return func() int { return x }()
+}
+
+// IIFEMutating is an immediately invoked closure that mutates a local variable.
+// The funcval is never stored — extreme non-escaping case.
+func IIFEMutating() int {
+	x := 0
+	func() { x++ }()
+	return x
+}
+
+// IIFEMutatingEscaping: the IIFE itself is immediately called, but the closure
+// it produces is returned and escapes.
+func IIFEMutatingEscaping() func() int {
+	x := 0
+	return func() func() int {
+		x++
+		return func() int { return x }
+	}()
+}
+
+// ---- Section 4: Multi-Variable Capture (all escaping) ----
+
+// CaptureOneVar returns a closure over 1 captured variable.
+func CaptureOneVar() func() int {
+	a := 1
+	return func() int { return a }
+}
+
+// CaptureTwoVars returns a closure over 2 captured variables.
+func CaptureTwoVars() func() int {
+	a, b := 1, 2
+	return func() int { return a + b }
+}
+
+// CaptureFourVars returns a closure over 4 captured variables.
+func CaptureFourVars() func() int {
+	a, b, c, d := 1, 2, 3, 4
+	return func() int { return a + b + c + d }
+}
+
+// CaptureEightVars returns a closure over 8 captured variables.
+func CaptureEightVars() func() int {
+	a, b, c, d, e, f, g, h := 1, 2, 3, 4, 5, 6, 7, 8
+	return func() int { return a + b + c + d + e + f + g + h }
+}
+
+// ---- Section 5: Nested Closures ----
+
+// NestedNeitherEscapes: both the outer and inner closures are used locally.
+func NestedNeitherEscapes() int {
+	x := 0
+	f := func() {
+		g := func() { x++ }
+		g()
+	}
+	f()
+	return x
+}
+
+// NestedInnerEscapes: the outer closure is called locally; the inner closure
+// it creates is returned and escapes.
+func NestedInnerEscapes() func() int {
+	x := 0
+	outer := func() func() int {
+		x++
+		return func() int { return x }
+	}
+	return outer()
+}
+
+// NestedOuterEscapes: the outer closure is returned (escapes); the inner
+// closure it creates is used only locally.
+func NestedOuterEscapes() func() int {
+	x := 0
+	return func() int {
+		inner := func() { x++ }
+		inner()
+		return x
+	}
+}
+
+// ---- Section 6: Pointer Capture ----
+
+// CapturePointerNonEscaping: closure reads via *int; the closure does not escape.
+func CapturePointerNonEscaping() int {
+	x := 42
+	p := &x
+	f := func() int { return *p }
+	return f()
+}
+
+// CapturePointerMutatingNonEscaping: closure mutates via *int; the closure does not escape.
+func CapturePointerMutatingNonEscaping() int {
+	x := 0
+	p := &x
+	f := func() { *p++ }
+	f()
+	return x
+}
+
+// CapturePointerEscaping: closure captures a *int and is returned (escapes).
+func CapturePointerEscaping() func() int {
+	x := 0
+	p := &x
+	return func() int { *p++; return *p }
+}

--- a/experiments/closure-capture/closure_test.go
+++ b/experiments/closure-capture/closure_test.go
@@ -1,0 +1,285 @@
+package closurecapture
+
+import "testing"
+
+// sink prevents the compiler from eliminating benchmark results via dead-code elimination.
+var sink int
+
+// TestAllocations measures heap allocations per call using testing.AllocsPerRun.
+//
+// Assertion policy:
+//   - Hard assertion (t.Errorf): patterns where the compiler outcome is determined
+//     by the Go spec or well-established escape analysis rules.
+//   - Observation only (t.Logf): exploratory patterns whose allocation count is
+//     the primary research question. These must NOT be constrained by a prior hypothesis.
+func TestAllocations(t *testing.T) {
+
+	// ---- Section 0: Baseline ----
+
+	t.Run("Baseline_NoCapture", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = NoCapture() })
+		if got != 0 {
+			t.Errorf("NoCapture: want 0 allocs, got %v", got)
+		}
+	})
+
+	// ---- Section 1: 2×2 Factorial ----
+
+	t.Run("PatternA_NonEscapingReadOnly", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = PatternA_NonEscapingReadOnly() })
+		if got != 0 {
+			t.Errorf("PatternA: want 0 allocs, got %v", got)
+		}
+	})
+
+	// PatternB is the core research question — observe without asserting.
+	t.Run("PatternB_NonEscapingMutating", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = PatternB_NonEscapingMutating() })
+		t.Logf("PatternB (main experiment — reference capture, non-escaping): allocs/run = %v", got)
+	})
+
+	// PatternC: the returned closure is immediately called in the test expression.
+	// With inlining enabled the compiler may fold the entire expression and eliminate
+	// the heap allocation even though the function signature implies escape.
+	// Observation only — this is part of the research result.
+	t.Run("PatternC_EscapingReadOnly", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = PatternC_EscapingReadOnly()() })
+		t.Logf("PatternC (escaping read-only, inlined call site): allocs/run = %v", got)
+	})
+
+	// PatternD: same inlining caveat as PatternC.
+	t.Run("PatternD_EscapingMutating", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = PatternD_EscapingMutating()() })
+		t.Logf("PatternD (escaping mutating, inlined call site): allocs/run = %v", got)
+	})
+
+	// ---- Section 2: Escape Mechanism Variants ----
+
+	t.Run("EscapeViaGlobal", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { EscapeViaGlobal() })
+		t.Logf("EscapeViaGlobal: allocs/run = %v", got)
+	})
+
+	t.Run("EscapeViaGoroutine", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = EscapeViaGoroutine() })
+		t.Logf("EscapeViaGoroutine: allocs/run = %v", got)
+	})
+
+	t.Run("EscapeViaInterface", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { EscapeViaInterface() })
+		t.Logf("EscapeViaInterface: allocs/run = %v", got)
+	})
+
+	// ---- Section 3: IIFE ----
+
+	t.Run("IIFEReadOnly", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = IIFEReadOnly() })
+		t.Logf("IIFEReadOnly: allocs/run = %v", got)
+	})
+
+	t.Run("IIFEMutating", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = IIFEMutating() })
+		t.Logf("IIFEMutating: allocs/run = %v", got)
+	})
+
+	t.Run("IIFEMutatingEscaping", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = IIFEMutatingEscaping()() })
+		t.Logf("IIFEMutatingEscaping: allocs/run = %v", got)
+	})
+
+	// ---- Section 4: Multi-Variable Capture ----
+
+	t.Run("CaptureOneVar", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = CaptureOneVar()() })
+		t.Logf("CaptureOneVar: allocs/run = %v", got)
+	})
+
+	t.Run("CaptureTwoVars", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = CaptureTwoVars()() })
+		t.Logf("CaptureTwoVars: allocs/run = %v", got)
+	})
+
+	t.Run("CaptureFourVars", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = CaptureFourVars()() })
+		t.Logf("CaptureFourVars: allocs/run = %v", got)
+	})
+
+	t.Run("CaptureEightVars", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = CaptureEightVars()() })
+		t.Logf("CaptureEightVars: allocs/run = %v", got)
+	})
+
+	// ---- Section 5: Nested Closures ----
+
+	t.Run("NestedNeitherEscapes", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = NestedNeitherEscapes() })
+		t.Logf("NestedNeitherEscapes: allocs/run = %v", got)
+	})
+
+	t.Run("NestedInnerEscapes", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = NestedInnerEscapes()() })
+		t.Logf("NestedInnerEscapes: allocs/run = %v", got)
+	})
+
+	t.Run("NestedOuterEscapes", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = NestedOuterEscapes()() })
+		t.Logf("NestedOuterEscapes: allocs/run = %v", got)
+	})
+
+	// ---- Section 6: Pointer Capture ----
+
+	t.Run("CapturePointerNonEscaping", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = CapturePointerNonEscaping() })
+		t.Logf("CapturePointerNonEscaping: allocs/run = %v", got)
+	})
+
+	t.Run("CapturePointerMutatingNonEscaping", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = CapturePointerMutatingNonEscaping() })
+		t.Logf("CapturePointerMutatingNonEscaping: allocs/run = %v", got)
+	})
+
+	t.Run("CapturePointerEscaping", func(t *testing.T) {
+		got := testing.AllocsPerRun(100, func() { sink = CapturePointerEscaping()() })
+		t.Logf("CapturePointerEscaping: allocs/run = %v", got)
+	})
+}
+
+// ---- Section 0: Baseline ----
+
+func BenchmarkBaseline_NoCapture(b *testing.B) {
+	for b.Loop() {
+		sink = NoCapture()
+	}
+}
+
+// ---- Section 1: 2×2 Factorial ----
+
+func BenchmarkPatternA_NonEscapingReadOnly(b *testing.B) {
+	for b.Loop() {
+		sink = PatternA_NonEscapingReadOnly()
+	}
+}
+
+func BenchmarkPatternB_NonEscapingMutating(b *testing.B) {
+	for b.Loop() {
+		sink = PatternB_NonEscapingMutating()
+	}
+}
+
+func BenchmarkPatternC_EscapingReadOnly(b *testing.B) {
+	for b.Loop() {
+		sink = PatternC_EscapingReadOnly()()
+	}
+}
+
+func BenchmarkPatternD_EscapingMutating(b *testing.B) {
+	for b.Loop() {
+		sink = PatternD_EscapingMutating()()
+	}
+}
+
+// ---- Section 2: Escape Mechanism Variants ----
+
+func BenchmarkEscapeViaGlobal(b *testing.B) {
+	for b.Loop() {
+		EscapeViaGlobal()
+	}
+}
+
+func BenchmarkEscapeViaGoroutine(b *testing.B) {
+	for b.Loop() {
+		sink = EscapeViaGoroutine()
+	}
+}
+
+func BenchmarkEscapeViaInterface(b *testing.B) {
+	for b.Loop() {
+		EscapeViaInterface()
+	}
+}
+
+// ---- Section 3: IIFE ----
+
+func BenchmarkIIFEReadOnly(b *testing.B) {
+	for b.Loop() {
+		sink = IIFEReadOnly()
+	}
+}
+
+func BenchmarkIIFEMutating(b *testing.B) {
+	for b.Loop() {
+		sink = IIFEMutating()
+	}
+}
+
+func BenchmarkIIFEMutatingEscaping(b *testing.B) {
+	for b.Loop() {
+		sink = IIFEMutatingEscaping()()
+	}
+}
+
+// ---- Section 4: Multi-Variable Capture ----
+
+func BenchmarkCaptureOneVar(b *testing.B) {
+	for b.Loop() {
+		sink = CaptureOneVar()()
+	}
+}
+
+func BenchmarkCaptureTwoVars(b *testing.B) {
+	for b.Loop() {
+		sink = CaptureTwoVars()()
+	}
+}
+
+func BenchmarkCaptureFourVars(b *testing.B) {
+	for b.Loop() {
+		sink = CaptureFourVars()()
+	}
+}
+
+func BenchmarkCaptureEightVars(b *testing.B) {
+	for b.Loop() {
+		sink = CaptureEightVars()()
+	}
+}
+
+// ---- Section 5: Nested Closures ----
+
+func BenchmarkNestedNeitherEscapes(b *testing.B) {
+	for b.Loop() {
+		sink = NestedNeitherEscapes()
+	}
+}
+
+func BenchmarkNestedInnerEscapes(b *testing.B) {
+	for b.Loop() {
+		sink = NestedInnerEscapes()()
+	}
+}
+
+func BenchmarkNestedOuterEscapes(b *testing.B) {
+	for b.Loop() {
+		sink = NestedOuterEscapes()()
+	}
+}
+
+// ---- Section 6: Pointer Capture ----
+
+func BenchmarkCapturePointerNonEscaping(b *testing.B) {
+	for b.Loop() {
+		sink = CapturePointerNonEscaping()
+	}
+}
+
+func BenchmarkCapturePointerMutatingNonEscaping(b *testing.B) {
+	for b.Loop() {
+		sink = CapturePointerMutatingNonEscaping()
+	}
+}
+
+func BenchmarkCapturePointerEscaping(b *testing.B) {
+	for b.Loop() {
+		sink = CapturePointerEscaping()()
+	}
+}

--- a/experiments/closure-capture/go.mod
+++ b/experiments/closure-capture/go.mod
@@ -1,0 +1,3 @@
+module go-lab/experiments/closure-capture
+
+go 1.26.0


### PR DESCRIPTION
## Summary

Closes #23

クロージャによる変数キャプチャがヒープアロケーションを引き起こす条件を、6グループ20パターンで系統的に測定した。

## Environment

| Key | Value |
|:---|:---|
| Go | `go1.26.0 darwin/arm64` |
| OS/Arch | `darwin/arm64` |
| CPU | Apple M2 |

## Results

### Size / Static Analysis

`go build -gcflags="-m -m"` によるエスケープ解析ログ（関数本体単位）では、以下の関数リテラルが「ヒープへエスケープ」と判定された。

| 関数 | 静的エスケープ判定 | 実測 allocs/op |
|:---|:---|---:|
| `PatternC_EscapingReadOnly` | func literal escapes to heap | **0** |
| `PatternD_EscapingMutating` | x moved to heap, func literal escapes | **0** |
| `CaptureOneVar` 〜 `CaptureEightVars` | func literal escapes to heap | **0** |
| `IIFEMutatingEscaping` | func literal escapes to heap | **0** |
| `NestedInnerEscapes`, `NestedOuterEscapes` | func literal escapes / x moved to heap | **0** |
| `CapturePointerEscaping` | x moved to heap, func literal escapes | **0** |
| `EscapeViaGlobal` | func literal escapes to heap | **1** |
| `EscapeViaGoroutine` | func literal escapes to heap | **2** |
| `EscapeViaInterface` | func literal escapes to heap | **1** |

静的解析では「エスケープ」と判定された関数の大部分が、ベンチマーク実行時は **0 allocs** を示した。インライン展開による再解析がヒープ割り当てを消去している。

### Benchmark

```text
goos: darwin
goarch: arm64
pkg: go-lab/experiments/closure-capture
cpu: Apple M2
BenchmarkBaseline_NoCapture-8                  	475867408	         2.353 ns/op	       0 B/op	       0 allocs/op
BenchmarkBaseline_NoCapture-8                  	584164516	         2.091 ns/op	       0 B/op	       0 allocs/op
BenchmarkBaseline_NoCapture-8                  	587348391	         2.104 ns/op	       0 B/op	       0 allocs/op
BenchmarkBaseline_NoCapture-8                  	549901350	         2.133 ns/op	       0 B/op	       0 allocs/op
BenchmarkBaseline_NoCapture-8                  	582816505	         2.111 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternA_NonEscapingReadOnly-8        	569013760	         2.099 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternA_NonEscapingReadOnly-8        	562547464	         2.153 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternA_NonEscapingReadOnly-8        	579543211	         2.060 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternA_NonEscapingReadOnly-8        	565917165	         2.089 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternA_NonEscapingReadOnly-8        	582668289	         2.088 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternB_NonEscapingMutating-8        	574592821	         2.093 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternB_NonEscapingMutating-8        	557776978	         2.127 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternB_NonEscapingMutating-8        	586953849	         2.111 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternB_NonEscapingMutating-8        	571208812	         2.076 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternB_NonEscapingMutating-8        	584069148	         2.078 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternC_EscapingReadOnly-8           	574346112	         2.125 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternC_EscapingReadOnly-8           	588074101	         2.090 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternC_EscapingReadOnly-8           	569240497	         2.088 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternC_EscapingReadOnly-8           	568328361	         2.072 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternC_EscapingReadOnly-8           	581544796	         2.109 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternD_EscapingMutating-8           	578048486	         2.041 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternD_EscapingMutating-8           	621561985	         1.972 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternD_EscapingMutating-8           	605156437	         1.996 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternD_EscapingMutating-8           	614230831	         1.965 ns/op	       0 B/op	       0 allocs/op
BenchmarkPatternD_EscapingMutating-8           	566993311	         1.997 ns/op	       0 B/op	       0 allocs/op
BenchmarkEscapeViaGlobal-8                     	100000000	        10.04 ns/op	      16 B/op	       1 allocs/op
BenchmarkEscapeViaGlobal-8                     	120472300	         9.996 ns/op	      16 B/op	       1 allocs/op
BenchmarkEscapeViaGlobal-8                     	120556654	         9.959 ns/op	      16 B/op	       1 allocs/op
BenchmarkEscapeViaGlobal-8                     	100000000	        10.43 ns/op	      16 B/op	       1 allocs/op
BenchmarkEscapeViaGlobal-8                     	100000000	        10.28 ns/op	      16 B/op	       1 allocs/op
BenchmarkEscapeViaGoroutine-8                  	 3171732	       372.1 ns/op	     152 B/op	       2 allocs/op
BenchmarkEscapeViaGoroutine-8                  	 3160302	       377.6 ns/op	     152 B/op	       2 allocs/op
BenchmarkEscapeViaGoroutine-8                  	 3182582	       379.5 ns/op	     152 B/op	       2 allocs/op
BenchmarkEscapeViaGoroutine-8                  	 3491370	       363.6 ns/op	     152 B/op	       2 allocs/op
BenchmarkEscapeViaGoroutine-8                  	 3151009	       374.1 ns/op	     152 B/op	       2 allocs/op
BenchmarkEscapeViaInterface-8                  	100000000	        10.13 ns/op	      16 B/op	       1 allocs/op
BenchmarkEscapeViaInterface-8                  	100000000	        10.02 ns/op	      16 B/op	       1 allocs/op
BenchmarkEscapeViaInterface-8                  	100000000	        10.33 ns/op	      16 B/op	       1 allocs/op
BenchmarkEscapeViaInterface-8                  	114514905	        10.59 ns/op	      16 B/op	       1 allocs/op
BenchmarkEscapeViaInterface-8                  	100000000	        10.15 ns/op	      16 B/op	       1 allocs/op
BenchmarkIIFEReadOnly-8                        	549792702	         2.123 ns/op	       0 B/op	       0 allocs/op
BenchmarkIIFEMutating-8                        	559578387	         2.135 ns/op	       0 B/op	       0 allocs/op
BenchmarkIIFEMutatingEscaping-8                	542343874	         2.148 ns/op	       0 B/op	       0 allocs/op
BenchmarkCaptureOneVar-8                       	546113709	         2.201 ns/op	       0 B/op	       0 allocs/op
BenchmarkCaptureTwoVars-8                      	547689804	         2.158 ns/op	       0 B/op	       0 allocs/op
BenchmarkCaptureFourVars-8                     	552018654	         2.145 ns/op	       0 B/op	       0 allocs/op
BenchmarkCaptureEightVars-8                    	544085058	         2.197 ns/op	       0 B/op	       0 allocs/op
BenchmarkNestedNeitherEscapes-8                	561394644	         2.121 ns/op	       0 B/op	       0 allocs/op
BenchmarkNestedInnerEscapes-8                  	490280360	         2.361 ns/op	       0 B/op	       0 allocs/op
BenchmarkNestedOuterEscapes-8                  	597168427	         2.076 ns/op	       0 B/op	       0 allocs/op
BenchmarkCapturePointerNonEscaping-8           	557413923	         2.158 ns/op	       0 B/op	       0 allocs/op
BenchmarkCapturePointerMutatingNonEscaping-8   	558984402	         2.144 ns/op	       0 B/op	       0 allocs/op
BenchmarkCapturePointerEscaping-8              	566231154	         2.050 ns/op	       0 B/op	       0 allocs/op
```

### Summary Table

#### Group 1: 2×2 Factorial（主実験）

| Pattern | キャプチャ | エスケープ | ns/op | B/op | allocs/op |
|:---|:---|:---|---:|---:|---:|
| NoCapture (baseline) | なし | なし | 2.1 | 0 | 0 |
| PatternA | 読み取り | なし | 2.1 | 0 | 0 |
| **PatternB** | **変更** | **なし** | **2.1** | **0** | **0** |
| PatternC | 読み取り | あり (return) | 2.1 | 0 | **0 ← 意外** |
| PatternD | 変更 | あり (return) | 2.0 | 0 | **0 ← 意外** |

#### Group 2: エスケープ機構（唯一実際に割り当てが発生したグループ）

| Pattern | エスケープ経路 | ns/op | B/op | allocs/op |
|:---|:---|---:|---:|---:|
| EscapeViaGlobal | グローバル変数代入 | 10.2 | 16 | 1 |
| EscapeViaInterface | interface{} ボクシング | 10.2 | 16 | 1 |
| EscapeViaGoroutine | goroutine 渡し | 373 | 152 | 2 |

#### Group 3–6: 全パターン 0 allocs

| Group | 代表パターン | allocs/op |
|:---|:---|---:|
| IIFE (即時実行) | IIFEMutatingEscaping | 0 |
| Multi-Capture 1〜8変数 | CaptureEightVars | 0 |
| Nested (多段) | NestedInnerEscapes | 0 |
| Pointer Capture | CapturePointerEscaping | 0 |

## Conclusion

- **Result**: `result:unexpected`

仮説「参照キャプチャ（PatternB）がヒープ割り当ての十分条件か」に対する答えは **No** だった。さらに踏み込んだ発見として、`return` によるエスケープや多変数キャプチャも含め、**インライン展開可能な全パターンが 0 allocs** を示した。

ヒープ割り当てを決定するのはエスケープ解析の判定ではなく、**コールサイトの不透明性**（グローバル変数・goroutine・interface{} など、インライナが追跡できない経路）であることが実測により確認された。`go build -gcflags="-m"` は関数本体単位のエスケープを報告するが、インライン展開後の再解析でその判定が覆り得る点が重要な知見となった。