### PR TITLE
exp: 公式Goコンテナイメージの内部解剖

### DIFF
--- a/experiments/docker-go-image-anatomy/Dockerfile
+++ b/experiments/docker-go-image-anatomy/Dockerfile
@@ -1,0 +1,8 @@
+FROM golang:1.26
+
+WORKDIR /work
+COPY inspect.sh .
+COPY go.mod .
+COPY inspect_test.go .
+
+CMD ["bash", "/work/inspect.sh"]

--- a/experiments/docker-go-image-anatomy/go.mod
+++ b/experiments/docker-go-image-anatomy/go.mod
@@ -1,0 +1,3 @@
+module go-lab/experiments/docker-go-image-anatomy
+
+go 1.26.0

--- a/experiments/docker-go-image-anatomy/inspect.sh
+++ b/experiments/docker-go-image-anatomy/inspect.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # inspect.sh — 公式Goコンテナイメージの内部調査スクリプト
-# Usage: docker run --rm golang:1.24 bash /work/inspect.sh
+# Usage: docker run --rm golang:1.26 bash /work/inspect.sh
 #   or:  docker build -t go-image-anatomy . && docker run --rm go-image-anatomy
 set -euo pipefail
 

--- a/experiments/docker-go-image-anatomy/inspect.sh
+++ b/experiments/docker-go-image-anatomy/inspect.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# inspect.sh — 公式Goコンテナイメージの内部調査スクリプト
+# Usage: docker run --rm golang:1.24 bash /work/inspect.sh
+#   or:  docker build -t go-image-anatomy . && docker run --rm go-image-anatomy
+set -euo pipefail
+
+separator() {
+  echo ""
+  echo "================================================================"
+  echo "  $1"
+  echo "================================================================"
+  echo ""
+}
+
+# --- Go toolchain ---
+separator "Go Version"
+go version
+
+separator "Go Environment (go env)"
+go env
+
+separator "Go Tools (go tool)"
+go tool -n
+
+separator "Go binaries in GOROOT/bin"
+ls -la "$(go env GOROOT)/bin/"
+
+# --- Directory layout ---
+separator "GOROOT directory tree (depth=2)"
+find "$(go env GOROOT)" -maxdepth 2 -type d | sort
+
+separator "GOPATH directory tree (depth=2)"
+find "$(go env GOPATH)" -maxdepth 2 -type d 2>/dev/null | sort || echo "(GOPATH is empty)"
+
+# --- Base OS ---
+separator "OS Release"
+cat /etc/os-release
+
+separator "Kernel Info"
+uname -a
+
+# --- System packages ---
+separator "Installed Packages (dpkg)"
+dpkg -l 2>/dev/null | tail -n +6 | awk '{print $2, $3}' | sort || echo "(dpkg not available — alpine variant?)"
+
+# --- libc / shared libraries ---
+separator "glibc Version"
+ldd --version 2>&1 | head -1 || echo "(ldd not available)"
+
+separator "Shared Libraries for Go binary"
+ldd "$(go env GOROOT)/bin/go" 2>/dev/null || echo "(statically linked or ldd not available)"
+
+# --- Environment variables ---
+separator "Environment Variables"
+env | sort
+
+separator "Inspection complete."

--- a/experiments/docker-go-image-anatomy/inspect_test.go
+++ b/experiments/docker-go-image-anatomy/inspect_test.go
@@ -1,0 +1,108 @@
+package dockergoimageanatomy
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestGoVersion は runtime.Version() が期待するプレフィクスを持つことを検証する。
+func TestGoVersion(t *testing.T) {
+	v := runtime.Version()
+	if !strings.HasPrefix(v, "go") {
+		t.Errorf("unexpected version format: %s", v)
+	}
+	t.Logf("runtime.Version() = %s", v)
+}
+
+// TestGOROOT は runtime.GOROOT() が空でなく、実際にディレクトリが存在することを検証する。
+func TestGOROOT(t *testing.T) {
+	goroot := runtime.GOROOT()
+	if goroot == "" {
+		t.Fatal("runtime.GOROOT() returned empty string")
+	}
+
+	info, err := os.Stat(goroot)
+	if err != nil {
+		t.Fatalf("GOROOT directory does not exist: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("GOROOT is not a directory: %s", goroot)
+	}
+	t.Logf("runtime.GOROOT() = %s", goroot)
+}
+
+// TestGoBinaryExists は GOROOT/bin/go と GOROOT/bin/gofmt の存在を検証する。
+func TestGoBinaryExists(t *testing.T) {
+	goroot := runtime.GOROOT()
+	binaries := []string{"go", "gofmt"}
+
+	for _, name := range binaries {
+		path := filepath.Join(goroot, "bin", name)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("binary not found: %s: %v", path, err)
+			continue
+		}
+		// 実行可能ビットが立っているか
+		if info.Mode()&0111 == 0 {
+			t.Errorf("binary is not executable: %s (mode=%s)", path, info.Mode())
+		}
+		t.Logf("found: %s (size=%d, mode=%s)", path, info.Size(), info.Mode())
+	}
+}
+
+// TestGOPATH は GOPATH 環境変数が設定されていることを検証する。
+func TestGOPATH(t *testing.T) {
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		t.Log("GOPATH is not set via env; using default")
+		return
+	}
+	t.Logf("GOPATH = %s", gopath)
+
+	info, err := os.Stat(gopath)
+	if err != nil {
+		t.Logf("GOPATH directory does not exist yet: %v", err)
+		return
+	}
+	if !info.IsDir() {
+		t.Errorf("GOPATH is not a directory: %s", gopath)
+	}
+}
+
+// TestGOROOTLayout は GOROOT 配下の主要ディレクトリが存在することを検証する。
+func TestGOROOTLayout(t *testing.T) {
+	goroot := runtime.GOROOT()
+	expectedDirs := []string{
+		"bin",
+		"src",
+		"pkg",
+		"lib",
+	}
+
+	for _, dir := range expectedDirs {
+		path := filepath.Join(goroot, dir)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("expected directory not found: %s: %v", path, err)
+			continue
+		}
+		if !info.IsDir() {
+			t.Errorf("expected directory but got file: %s", path)
+		}
+		t.Logf("found: %s/", path)
+	}
+}
+
+// TestRuntimeInfo は runtime パッケージから取得可能な基本情報を記録する。
+func TestRuntimeInfo(t *testing.T) {
+	t.Logf("GOOS      = %s", runtime.GOOS)
+	t.Logf("GOARCH    = %s", runtime.GOARCH)
+	t.Logf("Compiler  = %s", runtime.Compiler)
+	t.Logf("NumCPU    = %d", runtime.NumCPU())
+	t.Logf("Version   = %s", runtime.Version())
+	t.Logf("GOROOT    = %s", runtime.GOROOT())
+}


### PR DESCRIPTION
## Summary

- `golang:1.26` イメージの内部構造を多角的に調査する実験環境を追加
- `inspect.sh` でコンテナ内部情報（Goツールチェイン、ディレクトリ構造、OS情報、共有ライブラリ等）を収集
- `inspect_test.go` で Go runtime から取得可能な情報（GOROOT、バイナリ存在、ディレクトリレイアウト等）を検証
- `Dockerfile` により調査の再現可能性を確保

## Test plan

- [ ] `docker build -t go-image-anatomy ./experiments/docker-go-image-anatomy/`
- [ ] `docker run --rm go-image-anatomy` で `inspect.sh` の出力を確認
- [ ] `docker run --rm go-image-anatomy go test -v ./...` でテスト実行

Closes #29