### PR TITLE
exp: 公式GoコンテナイメージのDockerfileソースリーディング

### DIFF
--- a/experiments/docker-go-dockerfile-reading/analysis.sh
+++ b/experiments/docker-go-dockerfile-reading/analysis.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# analysis.sh — 公式GoコンテナイメージのDockerfile構造解析スクリプト
+# Usage: bash analysis.sh
+#
+# docker-library/golang リポジトリからDockerfileを取得し、構造を解析する。
+set -euo pipefail
+
+WORK_DIR="$(mktemp -d)"
+REPO_URL="https://github.com/docker-library/golang.git"
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+separator() {
+  echo ""
+  echo "================================================================"
+  echo "  $1"
+  echo "================================================================"
+  echo ""
+}
+
+# --- Dockerfileの取得 ---
+separator "Cloning docker-library/golang"
+git clone --depth 1 "$REPO_URL" "$WORK_DIR/golang"
+
+# --- Dockerfileの一覧 ---
+separator "Dockerfile variants"
+find "$WORK_DIR/golang" -name "Dockerfile" -type f | sort
+
+# --- bookworm Dockerfileの解析 ---
+BOOKWORM_DF="$(find "$WORK_DIR/golang" -path "*/bookworm/Dockerfile" -type f | head -1)"
+if [ -z "$BOOKWORM_DF" ]; then
+  echo "bookworm Dockerfile not found, searching for default..."
+  BOOKWORM_DF="$(find "$WORK_DIR/golang" -name "Dockerfile" -type f | head -1)"
+fi
+
+separator "Analyzing: $BOOKWORM_DF"
+
+separator "ENV directives"
+grep -n '^ENV\b' "$BOOKWORM_DF" || echo "(no ENV found)"
+
+separator "ARG directives"
+grep -n '^ARG\b' "$BOOKWORM_DF" || echo "(no ARG found)"
+
+separator "FROM directives"
+grep -n '^FROM\b' "$BOOKWORM_DF" || echo "(no FROM found)"
+
+separator "RUN directives (with line numbers)"
+grep -n '^RUN\b' "$BOOKWORM_DF" || echo "(no RUN found)"
+
+separator "Download URLs"
+grep -noE 'https?://[^ "]+' "$BOOKWORM_DF" || echo "(no URLs found)"
+
+separator "SHA256 / checksum references"
+grep -ni 'sha256\|checksum\|gpg\|signature' "$BOOKWORM_DF" || echo "(no checksum references found)"
+
+separator "Full Dockerfile content"
+cat -n "$BOOKWORM_DF"
+
+# --- alpine Dockerfileの解析 ---
+ALPINE_DF="$(find "$WORK_DIR/golang" -path "*/alpine/Dockerfile" -type f | head -1)"
+if [ -n "$ALPINE_DF" ]; then
+  separator "Alpine Dockerfile: ENV directives"
+  grep -n '^ENV\b' "$ALPINE_DF" || echo "(no ENV found)"
+
+  separator "Alpine Dockerfile: FROM directives"
+  grep -n '^FROM\b' "$ALPINE_DF" || echo "(no FROM found)"
+
+  separator "Alpine Dockerfile: Package installation (apk)"
+  grep -n 'apk' "$ALPINE_DF" || echo "(no apk commands found)"
+
+  separator "Diff: bookworm vs alpine (ENV lines)"
+  diff <(grep '^ENV' "$BOOKWORM_DF" | sort) <(grep '^ENV' "$ALPINE_DF" | sort) || echo "(differences found above)"
+else
+  separator "Alpine Dockerfile not found"
+fi
+
+separator "Analysis complete."

--- a/experiments/docker-go-dockerfile-reading/analysis_test.go
+++ b/experiments/docker-go-dockerfile-reading/analysis_test.go
@@ -1,0 +1,107 @@
+package dockergodockerfilereading
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestGOROOTMatchesDockerfileExpectation は、Dockerfileで設定されるGOROOTが
+// 実際のコンテナ内の値と一致することを検証する。
+// 公式Dockerfileでは ENV GOROOT /usr/local/go が設定される。
+func TestGOROOTMatchesDockerfileExpectation(t *testing.T) {
+	expected := "/usr/local/go"
+	actual := runtime.GOROOT()
+	if actual != expected {
+		t.Errorf("GOROOT mismatch: expected=%s, actual=%s", expected, actual)
+	}
+	t.Logf("GOROOT = %s (expected: %s)", actual, expected)
+}
+
+// TestGOPATHMatchesDockerfileExpectation は、Dockerfileで設定されるGOPATHが
+// 実際のコンテナ内の値と一致することを検証する。
+// 公式Dockerfileでは ENV GOPATH /go が設定される。
+func TestGOPATHMatchesDockerfileExpectation(t *testing.T) {
+	expected := "/go"
+	actual := os.Getenv("GOPATH")
+	if actual == "" {
+		t.Skip("GOPATH not set via environment variable (not running in container?)")
+	}
+	if actual != expected {
+		t.Errorf("GOPATH mismatch: expected=%s, actual=%s", expected, actual)
+	}
+	t.Logf("GOPATH = %s (expected: %s)", actual, expected)
+}
+
+// TestPATHContainsGoBinaries は、PATHに Go のバイナリディレクトリが
+// 含まれていることを検証する。
+// 公式Dockerfileでは PATH に /go/bin と /usr/local/go/bin が追加される。
+func TestPATHContainsGoBinaries(t *testing.T) {
+	pathEnv := os.Getenv("PATH")
+	if pathEnv == "" {
+		t.Fatal("PATH is empty")
+	}
+
+	expectedPaths := []string{
+		"/usr/local/go/bin",
+	}
+
+	for _, ep := range expectedPaths {
+		found := false
+		for _, p := range strings.Split(pathEnv, ":") {
+			if p == ep {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("PATH does not contain %s", ep)
+		}
+	}
+	t.Logf("PATH = %s", pathEnv)
+}
+
+// TestGOLANG_VERSION は GOLANG_VERSION 環境変数が設定されていることを検証する。
+// 公式Dockerfileでは ENV GOLANG_VERSION が設定される。
+func TestGOLANG_VERSION(t *testing.T) {
+	version := os.Getenv("GOLANG_VERSION")
+	if version == "" {
+		t.Skip("GOLANG_VERSION not set (not running in official container?)")
+	}
+
+	runtimeVersion := strings.TrimPrefix(runtime.Version(), "go")
+	if !strings.HasPrefix(runtimeVersion, version) && !strings.HasPrefix(version, runtimeVersion) {
+		t.Errorf("GOLANG_VERSION=%s does not match runtime.Version()=%s", version, runtime.Version())
+	}
+	t.Logf("GOLANG_VERSION = %s, runtime.Version() = %s", version, runtime.Version())
+}
+
+// TestGoDownloadSource は、Goバイナリの取得元が dl.google.com であることを
+// 間接的に検証する（バイナリが正規のものであることの確認）。
+func TestGoDownloadSource(t *testing.T) {
+	// runtime.Version() が公式リリースの形式であることを確認
+	v := runtime.Version()
+	if !strings.HasPrefix(v, "go1.") && !strings.HasPrefix(v, "go2.") {
+		t.Logf("non-release version detected: %s (possibly built from source)", v)
+	}
+	t.Logf("Go version: %s (compiler: %s)", v, runtime.Compiler)
+
+	if runtime.Compiler != "gc" {
+		t.Errorf("expected gc compiler, got: %s", runtime.Compiler)
+	}
+}
+
+// TestBaseOS は、コンテナのベースOSが Debian bookworm であることを検証する。
+func TestBaseOS(t *testing.T) {
+	data, err := os.ReadFile("/etc/os-release")
+	if err != nil {
+		t.Skip("cannot read /etc/os-release (not running in container?)")
+	}
+
+	content := string(data)
+	if !strings.Contains(content, "bookworm") && !strings.Contains(content, "Debian") {
+		t.Logf("unexpected base OS (may be alpine or other variant)")
+	}
+	t.Logf("/etc/os-release:\n%s", content)
+}

--- a/experiments/docker-go-dockerfile-reading/go.mod
+++ b/experiments/docker-go-dockerfile-reading/go.mod
@@ -1,0 +1,3 @@
+module go-lab/experiments/docker-go-dockerfile-reading
+
+go 1.26.0


### PR DESCRIPTION
## Summary

- `docker-library/golang` リポジトリのDockerfileを取得・解析する実験環境を追加
- `analysis.sh` でDockerfileの構造を解析（ENV/ARG抽出、ダウンロードURL、チェックサム参照、bookworm vs alpine の差分）
- `analysis_test.go` でDockerfileの設定値（GOROOT, GOPATH, PATH, GOLANG_VERSION等）が実際のコンテナ状態と一致するかを検証

## Test plan

- [x] `bash experiments/docker-go-dockerfile-reading/analysis.sh` で Dockerfile 解析結果を確認
- [x] `docker run --rm -v $(pwd)/experiments/docker-go-dockerfile-reading:/work -w /work golang:1.26 go test -v ./...` でテスト実行

Closes #30