### PR TITLE
exp: string ↔ []byte 変換のゼロコピー最適化条件の測定

### DIFF
--- a/experiments/string-zero-copy/conversion.go
+++ b/experiments/string-zero-copy/conversion.go
@@ -1,0 +1,56 @@
+package stringzerocopy
+
+// sink prevents the compiler from eliminating dead code.
+var sink int
+
+// BytesToStringAssign converts []byte to string via assignment.
+// The result escapes to the caller, forcing a heap allocation.
+//
+//go:noinline
+func BytesToStringAssign(b []byte) string {
+	s := string(b)
+	return s
+}
+
+// StringToBytesAssign converts string to []byte via assignment.
+// The result escapes to the caller, forcing a heap allocation.
+//
+//go:noinline
+func StringToBytesAssign(s string) []byte {
+	b := []byte(s)
+	return b
+}
+
+// BytesToStringMapLookup performs a map lookup using string(b) as the key.
+// The compiler recognizes this pattern and avoids allocating a new string.
+//
+//go:noinline
+func BytesToStringMapLookup(m map[string]int, b []byte) int {
+	return m[string(b)]
+}
+
+// StringToBytesRange iterates over []byte(s) using a range loop.
+// The compiler recognizes this pattern and avoids allocating a new slice.
+//
+//go:noinline
+func StringToBytesRange(s string) {
+	for _, v := range []byte(s) {
+		sink += int(v)
+	}
+}
+
+// BytesToStringCompare compares string(b) against a string literal.
+// The compiler recognizes this pattern and avoids allocating a new string.
+//
+//go:noinline
+func BytesToStringCompare(b []byte, target string) bool {
+	return string(b) == target
+}
+
+// BytesToStringConcat concatenates a prefix with string(b).
+// A new string must be allocated for the result.
+//
+//go:noinline
+func BytesToStringConcat(b []byte) string {
+	return "prefix:" + string(b)
+}

--- a/experiments/string-zero-copy/conversion_test.go
+++ b/experiments/string-zero-copy/conversion_test.go
@@ -1,0 +1,88 @@
+package stringzerocopy
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+var sizes = []int{8, 64, 512, 4096}
+
+func makeBytes(n int) []byte  { return []byte(strings.Repeat("a", n)) }
+func makeString(n int) string { return strings.Repeat("a", n) }
+func makeMap(n int) map[string]int {
+	m := map[string]int{strings.Repeat("a", n): 1}
+	return m
+}
+
+// --- Copy patterns (expect allocs/op = 1) ---
+
+func BenchmarkBytesToStringAssign(b *testing.B) {
+	for _, n := range sizes {
+		bs := makeBytes(n)
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			for b.Loop() {
+				_ = BytesToStringAssign(bs)
+			}
+		})
+	}
+}
+
+func BenchmarkStringToBytesAssign(b *testing.B) {
+	for _, n := range sizes {
+		s := makeString(n)
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			for b.Loop() {
+				_ = StringToBytesAssign(s)
+			}
+		})
+	}
+}
+
+func BenchmarkBytesToStringConcat(b *testing.B) {
+	for _, n := range sizes {
+		bs := makeBytes(n)
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			for b.Loop() {
+				_ = BytesToStringConcat(bs)
+			}
+		})
+	}
+}
+
+// --- Zero-copy patterns (expect allocs/op = 0) ---
+
+func BenchmarkBytesToStringMapLookup(b *testing.B) {
+	for _, n := range sizes {
+		bs := makeBytes(n)
+		m := makeMap(n)
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			for b.Loop() {
+				_ = BytesToStringMapLookup(m, bs)
+			}
+		})
+	}
+}
+
+func BenchmarkStringToBytesRange(b *testing.B) {
+	for _, n := range sizes {
+		s := makeString(n)
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			for b.Loop() {
+				StringToBytesRange(s)
+			}
+		})
+	}
+}
+
+func BenchmarkBytesToStringCompare(b *testing.B) {
+	for _, n := range sizes {
+		bs := makeBytes(n)
+		target := makeString(n)
+		b.Run(fmt.Sprintf("N=%d", n), func(b *testing.B) {
+			for b.Loop() {
+				_ = BytesToStringCompare(bs, target)
+			}
+		})
+	}
+}

--- a/experiments/string-zero-copy/go.mod
+++ b/experiments/string-zero-copy/go.mod
@@ -1,0 +1,3 @@
+module go-lab/experiments/string-zero-copy
+
+go 1.26.0


### PR DESCRIPTION
## Summary

Closes #33

string ↔ []byte 変換においてコンパイラのゼロコピー最適化が発動する条件を測定し、
代入・結合（コピー）と map lookup・range・比較（ゼロコピー）の allocs/op の差を定量化した。

## Environment

| Key | Value |
|:---|:---|
| Go | `go1.26.0 darwin/arm64` |
| OS/Arch | `darwin/arm64` |
| CPU | Apple M2 |

## Results

### Size / Static Analysis

Escape analysis (`-gcflags="-m=1"`) による変換のエスケープ判定:

| Pattern | Verdict | Note |
|:---|:---|:---|
| `str := string(b)` | `escapes to heap` | コピー発生 |
| `bs := []byte(s)` | `escapes to heap` | コピー発生 |
| `"prefix:" + string(b)` | `escapes to heap` | 結合結果がコピー |
| `m[string(b)]` | `does not escape` | ゼロコピー |
| `for range []byte(s)` | `does not escape` + **`zero-copy string->[]byte conversion`** | ゼロコピー (コンパイラが明示) |
| `string(b) == target` | `does not escape` | ゼロコピー |

### Benchmark

```text
BenchmarkBytesToStringAssign/N=8-8       100000000    10.27 ns/op    8 B/op    1 allocs/op
BenchmarkBytesToStringAssign/N=64-8       83149998    14.32 ns/op   64 B/op    1 allocs/op
BenchmarkBytesToStringAssign/N=512-8      23006685    53.45 ns/op  512 B/op    1 allocs/op
BenchmarkBytesToStringAssign/N=4096-8      3269258   368.5  ns/op 4096 B/op    1 allocs/op

BenchmarkStringToBytesAssign/N=8-8       100000000    11.33 ns/op    8 B/op    1 allocs/op
BenchmarkStringToBytesAssign/N=64-8       78553525    16.18 ns/op   64 B/op    1 allocs/op
BenchmarkStringToBytesAssign/N=512-8      19818003    67.56 ns/op  512 B/op    1 allocs/op
BenchmarkStringToBytesAssign/N=4096-8      2780358   445.5  ns/op 4096 B/op    1 allocs/op

BenchmarkBytesToStringConcat/N=8-8        57441002    20.85 ns/op   16 B/op    1 allocs/op
BenchmarkBytesToStringConcat/N=64-8       54457579    23.65 ns/op   80 B/op    1 allocs/op
BenchmarkBytesToStringConcat/N=512-8      19090204    63.74 ns/op  576 B/op    1 allocs/op
BenchmarkBytesToStringConcat/N=4096-8      3465252   348.4  ns/op 4864 B/op    1 allocs/op

BenchmarkBytesToStringMapLookup/N=8-8    147791623     8.191 ns/op   0 B/op    0 allocs/op
BenchmarkBytesToStringMapLookup/N=64-8   129974262     9.275 ns/op   0 B/op    0 allocs/op
BenchmarkBytesToStringMapLookup/N=512-8   50436150    22.98  ns/op   0 B/op    0 allocs/op
BenchmarkBytesToStringMapLookup/N=4096-8  12732015    92.81  ns/op   0 B/op    0 allocs/op

BenchmarkStringToBytesRange/N=8-8         77708253    16.28 ns/op    0 B/op    0 allocs/op
BenchmarkStringToBytesRange/N=64-8         9072903   129.3  ns/op    0 B/op    0 allocs/op
BenchmarkStringToBytesRange/N=512-8        1000000  1139    ns/op    0 B/op    0 allocs/op
BenchmarkStringToBytesRange/N=4096-8        139286  8633    ns/op    0 B/op    0 allocs/op

BenchmarkBytesToStringCompare/N=8-8      374363872     3.328 ns/op   0 B/op    0 allocs/op
BenchmarkBytesToStringCompare/N=64-8     346515104     3.384 ns/op   0 B/op    0 allocs/op
BenchmarkBytesToStringCompare/N=512-8     96198168    12.28  ns/op   0 B/op    0 allocs/op
BenchmarkBytesToStringCompare/N=4096-8    14024138    81.72  ns/op   0 B/op    0 allocs/op
```

### Summary Table

N=8 (オーバーヘッドが最も顕在化するサイズ) での比較:

| Metric | Copy (Assign) | Zero-copy (Compare) | Diff |
|:---|---:|---:|:---|
| allocs/op | 1 | 0 | -100% |
| ns/op | 10.3 ns | 3.3 ns | -68% |
| B/op | 8 B | 0 B | -100% |

## Conclusion

- **Result**: `result:verified`
- ゼロコピー最適化はコンパイラが変換結果の **生存期間を一時的と判断できる** コンテキスト（map lookup のキー・range のソース・比較の被演算子）でのみ発動し、代入・結合では発動しないことを allocs/op = 0 で実測確認した。